### PR TITLE
Removed pressing echelon 2 before resupplying

### DIFF
--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map4_3E.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map4_3E.kt
@@ -54,7 +54,6 @@ class Map4_3E(
 
         logger.info("Deploying echelon 2 to command post")
         region.clickUntilGone("$PREFIX/commandpost.png", 10)
-        region.find("echelons/echelon2.png").clickRandomly(); yield()
         region.find("ok.png").clickRandomly()
 
         delay(200)

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map5_4.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map5_4.kt
@@ -54,7 +54,6 @@ class Map5_4(
 
         logger.info("Deploying echelon 2 to command post")
         region.clickUntilGone("$PREFIX/commandpost.png", 10)
-        region.find("echelons/echelon2.png").clickRandomly(); yield()
         region.find("ok.png").clickRandomly()
 
         delay(200)


### PR DESCRIPTION
Removed Line 57 in 4-3E and 5-4 which presses echelon 2 before resupplying. 