### PR TITLE
Update old bossfarm maps for new deployEchelons, cleanup

### DIFF
--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map10_4E.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map10_4E.kt
@@ -55,7 +55,8 @@ class Map10_4E(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptCom
             mapH = null
         }
         delay((900 * gameState.delayCoefficient).roundToLong()) //Wait to settle
-        val rEchelons = deployEchelons(nodes[0], nodes[1], nodes[2])
+        val rEchelons = deployEchelons(nodes[0])
+        deployEchelons(nodes[1], nodes[2]) // dummy
 
         //Heavyports are configured now
         gameState.requiresMapInit = false

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map11_5.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map11_5.kt
@@ -35,7 +35,7 @@ class Map11_5(scriptComponent: ScriptComponent) : AbsoluteMapRunner(scriptCompon
         // No need to zoom, delay for map lag
         delay((1000 * gameState.delayCoefficient).roundToLong())
         val rEchelons = deployEchelons(nodes[1], nodes[0])
-        // Dummy do not supply
+        // dummy
         deployEchelons(nodes[2])
         mapRunnerRegions.startOperation.click(); yield()
         waitForGNKSplash()
@@ -43,14 +43,12 @@ class Map11_5(scriptComponent: ScriptComponent) : AbsoluteMapRunner(scriptCompon
         retreatEchelons(nodes[0])
         planPath()
         // Wait for team to move all the way
-        waitForTurnEnd(5, false); delay(1000)
         waitForTurnAndPoints(1, 0, false); delay(1000)
         retreatEchelons(nodes[0])
         terminateMission()
     }
 
     private suspend fun planPath() {
-
         enterPlanningMode()
 
         logger.info("Selecting echelon at ${nodes[1]}")
@@ -65,5 +63,4 @@ class Map11_5(scriptComponent: ScriptComponent) : AbsoluteMapRunner(scriptCompon
         logger.info("Executing plan")
         mapRunnerRegions.executePlan.click()
     }
-
 }

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map1_6.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map1_6.kt
@@ -48,10 +48,10 @@ class Map1_6(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptCompo
             gameState.requiresMapInit = false
         }
 
-        deployEchelons(nodes[0])
+        val rEchelons = deployEchelons(nodes[0])
         mapRunnerRegions.startOperation.click(); yield()
         waitForGNKSplash()
-        resupplyEchelons(nodes[0]) //Force resupply so echelons with no doll in slot 2 can run
+        resupplyEchelons(rEchelons)
         planPath()
 
         // SF moves random, can cap a HP, scarecrow can run away and hide

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map2_6.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map2_6.kt
@@ -30,6 +30,8 @@ import kotlin.random.Random
 
 class Map2_6(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComponent) {
     private val logger = loggerFor<Map2_6>()
+    override val ammoResupplyThreshold = 0.6
+    override val rationsResupplyThreshold = 0.6
 
     override suspend fun begin() {
         if (gameState.requiresMapInit) {

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map3_4E.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map3_4E.kt
@@ -29,7 +29,8 @@ import kotlin.random.Random
 
 class Map3_4E(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComponent) {
     private val logger = loggerFor<Map3_4E>()
-    override val rationsResupplyThreshold = 0.5
+    override val ammoResupplyThreshold = 0.4
+    override val rationsResupplyThreshold = 0.4
 
     override suspend fun begin() {
         if (gameState.requiresMapInit) {
@@ -47,7 +48,8 @@ class Map3_4E(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComp
             gameState.requiresMapInit = false
         }
 
-        val rEchelons = deployEchelons(nodes[0], nodes[1])
+        val rEchelons = deployEchelons(nodes[0])
+        deployEchelons(nodes[1])
         mapRunnerRegions.startOperation.click(); yield()
         waitForGNKSplash()
         resupplyEchelons(rEchelons)

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map3_6.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map3_6.kt
@@ -20,7 +20,6 @@
 package com.waicool20.wai2k.script.modules.combat.maps
 
 
-import com.waicool20.cvauto.core.template.FileTemplate
 import com.waicool20.wai2k.script.ScriptComponent
 import com.waicool20.wai2k.script.modules.combat.HomographyMapRunner
 import com.waicool20.waicoolutils.logging.loggerFor
@@ -31,6 +30,8 @@ import kotlin.random.Random
 
 class Map3_6(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComponent) {
     private val logger = loggerFor<Map3_6>()
+    override val ammoResupplyThreshold = 0.6
+    override val rationsResupplyThreshold = 0.6
 
     override suspend fun begin() {
         if (gameState.requiresMapInit) {
@@ -48,15 +49,13 @@ class Map3_6(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptCompo
             gameState.requiresMapInit = false
         }
 
-        val rEchelons = deployEchelons(nodes[0], nodes[1])
+        val rEchelons = deployEchelons(nodes[0])
+        deployEchelons(nodes[1])
         mapRunnerRegions.startOperation.click(); yield()
         waitForGNKSplash()
         resupplyEchelons(rEchelons)
         planPath()
-        // Possible to get ambushed, so battle count unreliable
         waitForTurnAndPoints(1, 1, false); delay(500)
-        // Need to stop these turn end methods triggering before the battle
-        waitForTurnAssets(listOf(FileTemplate("combat/battle/plan.png", 0.96)), false)
         handleBattleResults()
     }
 

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map4_4N.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map4_4N.kt
@@ -45,10 +45,11 @@ class Map4_4N(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComp
             gameState.requiresMapInit = false
         }
 
-        deployEchelons(nodes[0], nodes[1])
+        val rEchelons = deployEchelons(nodes[0])
+        deployEchelons(nodes[1])
         mapRunnerRegions.startOperation.click(); yield()
         waitForGNKSplash()
-        resupplyEchelons(nodes[0])
+        resupplyEchelons(rEchelons)
         planPath()
         waitForTurnEnd(4)
         terminateMission()
@@ -56,6 +57,9 @@ class Map4_4N(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComp
 
     private suspend fun planPath() {
         enterPlanningMode()
+
+        logger.info("Selecting Echelon at ${nodes[0]}")
+        nodes[0].findRegion().click()
 
         logger.info("Selecting ${nodes[2]}")
         nodes[2].findRegion().click()

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map4_6.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map4_6.kt
@@ -29,6 +29,8 @@ import kotlin.random.Random
 
 class Map4_6(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComponent) {
     private val logger = loggerFor<Map4_6>()
+    override val ammoResupplyThreshold = 0.8
+    override val rationsResupplyThreshold = 0.6
 
     override suspend fun begin() {
         if (gameState.requiresMapInit) {
@@ -45,7 +47,8 @@ class Map4_6(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptCompo
             delay((900 * gameState.delayCoefficient).roundToLong())
             gameState.requiresMapInit = false
         }
-        val rEchelons = deployEchelons(nodes[0], nodes[1])
+        val rEchelons = deployEchelons(nodes[0])
+        deployEchelons(nodes[1])
         mapRunnerRegions.startOperation.click(); yield()
         waitForGNKSplash()
         resupplyEchelons(rEchelons)

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map5_6.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map5_6.kt
@@ -28,7 +28,8 @@ import kotlin.random.Random
 
 class Map5_6(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComponent) {
     private val logger = loggerFor<Map5_6>()
-    override val rationsResupplyThreshold = 0.5 // only 2 battles
+    override val ammoResupplyThreshold = 0.4
+    override val rationsResupplyThreshold = 0.4
 
     override suspend fun begin() {
         if (gameState.requiresMapInit) {
@@ -49,7 +50,8 @@ class Map5_6(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptCompo
             delay(500)
             gameState.requiresMapInit = false
         }
-        val rEchelons = deployEchelons(nodes[0], nodes[1])
+        val rEchelons = deployEchelons(nodes[0])
+        deployEchelons(nodes[1])
         mapRunnerRegions.startOperation.click(); yield()
         waitForGNKSplash()
         resupplyEchelons(rEchelons)

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map6_4N.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/combat/maps/Map6_4N.kt
@@ -29,6 +29,9 @@ import kotlin.random.Random
 
 class Map6_4N(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComponent) {
     private val logger = loggerFor<Map6_4N>()
+    override val ammoResupplyThreshold = 0.6
+    override val rationsResupplyThreshold = 0.6
+
 
     override suspend fun begin() {
         if (gameState.requiresMapInit) {
@@ -45,7 +48,8 @@ class Map6_4N(scriptComponent: ScriptComponent) : HomographyMapRunner(scriptComp
             gameState.requiresMapInit = false
         }
 
-        val rEchelons = deployEchelons(nodes[0], nodes[2])
+        val rEchelons = deployEchelons(nodes[0])
+        deployEchelons(nodes[1])
         mapRunnerRegions.startOperation.click(); yield()
         waitForGNKSplash()
         resupplyEchelons(rEchelons)


### PR DESCRIPTION
        val rEchelons = deployEchelons(nodes[0] , nodes[1])
        resupplyEchelons(rEchelons)

       Previously nodes[1] would not get resupplied if it was a (1tdoll) dummy, now it will.
       I updated the map scripts accordingly.