### PR TITLE
6 star filter gameState property

### DIFF
--- a/src/main/kotlin/com/waicool20/wai2k/game/GameState.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/game/GameState.kt
@@ -30,6 +30,7 @@ class GameState {
     var dollOverflow: Boolean = false
     var equipOverflow: Boolean = false
     var switchDolls: Boolean = false
+    var sixStarFilter: Boolean? = null
     var currentGameLocation: GameLocation = GameLocation(LocationId.UNKNOWN)
     val echelons: List<Echelon> = List(10) { Echelon(it + 1) }
     var simEnergy: Int = 0

--- a/src/main/kotlin/com/waicool20/wai2k/script/modules/ScriptModule.kt
+++ b/src/main/kotlin/com/waicool20/wai2k/script/modules/ScriptModule.kt
@@ -102,17 +102,25 @@ abstract class ScriptModule(
         }
         if (stars.isNotEmpty()) {
             logger.info("Applying $stars stars filter")
-            val unlockedStars = dollFilterRegions.starRegions[6]?.let {
-                ocr.readText(it.subRegion(92, 70, 28, 39))
+            if (gameState.sixStarFilter == null) {
+                val unlockedStars = dollFilterRegions.starRegions[6]?.let {
+                    ocr.readText(it.subRegion(92, 70, 28, 39))
+                }
+                if (unlockedStars?.contains("6") == true) {
+                    logger.info("6 star filter is unlocked")
+                    gameState.sixStarFilter = true                
+                } else {
+                    logger.info("6 star filter isn't unlocked")
+                    gameState.sixStarFilter = false
+                } 
             }
-            if (unlockedStars?.contains("6") == true) {
-                logger.info("6 star filter is unlocked")
+
+            if (gameState.sixStarFilter == true) {
                 stars.forEach {
                     dollFilterRegions.starRegions[it]?.click()
                     delay(100)
                 }
             } else {
-                logger.info("6 star filter isn't unlocked")
                 stars.forEach {
                     dollFilterRegions.starRegions[it + 1]?.click()
                     delay(100)


### PR DESCRIPTION
Makes the six star filter part of the game state.
Makes it so we only check if it is unlocked once.
I did this to try and alleviate the delay between opening the filter menu and applying the filters, but it doesn't seem to have much of an effect on it.
Still, every bit can help. 